### PR TITLE
perf: make verification 50% faster

### DIFF
--- a/t/load-verify.t
+++ b/t/load-verify.t
@@ -32,7 +32,7 @@ __DATA__
 --- request
 GET /t
 --- response_body
-urlsafe b64encoded {foo: bar}: eyJmb28iOiJiYXIifQ2
+urlsafe b64encoded {foo: bar}: eyJmb28iOiJiYXIifQ
 --- no_error_log
 [error]
 
@@ -52,7 +52,7 @@ urlsafe b64encoded {foo: bar}: eyJmb28iOiJiYXIifQ2
 --- request
 GET /t
 --- response_body
-urlsafe b64encoded {foo: bar}: eyJmb28iOiJiYXIifQ2
+urlsafe b64encoded {foo: bar}: eyJmb28iOiJiYXIifQ
 --- no_error_log
 [error]
 


### PR DESCRIPTION
1. use plain text string split
2. avoid temporary string
3. avoid temporary table
4. avoid creating new functions in hot path

Also fix a bug in the upstream.