### PR TITLE
fix(openssl): d2i_ECDSA_SIG API parameter pp type error

### DIFF
--- a/lib/resty/evp.lua
+++ b/lib/resty/evp.lua
@@ -91,7 +91,7 @@ typedef struct ECDSA_SIG_st {
     BIGNUM *s;} ECDSA_SIG;
 ECDSA_SIG*     ECDSA_SIG_new(void);
 int            i2d_ECDSA_SIG(const ECDSA_SIG *sig, unsigned char **pp);
-ECDSA_SIG*     d2i_ECDSA_SIG(ECDSA_SIG **sig, unsigned char **pp,
+ECDSA_SIG*     d2i_ECDSA_SIG(ECDSA_SIG **sig, const unsigned char **pp,
 long len);
 void           ECDSA_SIG_free(ECDSA_SIG *sig);
 
@@ -397,12 +397,10 @@ function ECSigner.get_raw_sig(self, signature)
     if not signature then
         return nil, "Must pass a signature to convert"
     end
-    local sig_ptr = ffi_new("unsigned char *[1]")
-    local sig_bin = ffi_new("unsigned char [?]", #signature)
-    ffi_copy(sig_bin, signature, #signature)
 
-    sig_ptr[0] = sig_bin
-    local sig = _C.d2i_ECDSA_SIG(nil, sig_ptr, #signature)
+    local buf = ffi_new("const unsigned char*", signature)
+    local buf_ptr = ffi_new("const unsigned char*[1]", buf)
+    local sig = _C.d2i_ECDSA_SIG(nil, buf_ptr, #signature)
     ffi_gc(sig, _C.ECDSA_SIG_free)
 
     local rbytes = math.floor((_C.BN_num_bits(sig.r)+7)/8)


### PR DESCRIPTION
https://docs.openssl.org/1.0.2/man3/ecdsa/#synopsis

<img width="696" alt="image" src="https://github.com/user-attachments/assets/9ed12fe8-d68a-4162-a909-cde444618431">

If multiple libraries use this API separately, but their declared function parameter types are inconsistent, it may cause other libraries to be unable to call correctly.

Because when redefining declarations in `ffi.cdef`, they will be overwritten, and their handling methods will vary depending on the parameter types.

It should be used according to the officially defined types of openssl.

```log
resty/openssl/auxiliary/ecdsa.lua:51: bad argument #2 to 'd2i_ECDSA_SIG' (cannot convert 'const unsigned char *[1]' to 'unsigned char **')
```
